### PR TITLE
Fix unsupported method in IE

### DIFF
--- a/src/Search.js
+++ b/src/Search.js
@@ -24,7 +24,7 @@ class Search extends Component {
 
    let filteredMovies = movieArraySearch.filter(
       (episode) => {
-        return episode.movieTitle.toLowerCase().includes(this.state.search.toLowerCase());
+        return episode.movieTitle.toLowerCase().indexOf(this.state.search.toLowerCase()) > -1;
       }
     );
 


### PR DESCRIPTION
I saw your issue on the CRA repo.

You're using String.prototype.includes in your Search component, which is not supported in IE.
